### PR TITLE
A few CLI improvements

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -30,6 +30,9 @@ The following environment variables are detected by the CLI, and will be used wh
    - The URL of your chosen Zipline instance.
 - ``ZIPLINE_TOKEN`` (string)
    - An authentication token to use for API requests.
+- ``ZIPLINE_PRINT_OBJECT`` (boolean)
+   - Determines whether or not to print the full Python object returned by the zipline.py client.
+   - Consider using the CLI arguments (usually ``--object`` or ``--text``) on specific commands to override this instead of a global environment variable, as the default behavior for commands using this changes depending on whether or not they are used in a TTY.
 - ``ZIPLINE_VERBOSE`` (boolean)
    - Determines whether or not to print exception tracebacks when the application encounters an exception that it is meant to handle.
    - If the application encounters an unexpected exception, this option is ignored and the traceback will always be printed.

--- a/zipline/cli/commands/shorten.py
+++ b/zipline/cli/commands/shorten.py
@@ -37,7 +37,7 @@ async def shorten(
         ...,
         "--object/--text",
         "-o/-O",
-        default_factory=lambda: bool(sys.stdout.isatty()),
+        default_factory=sys.stdout.isatty,
         help=(
             "Choose how to format the output. "
             "If --text (or piped), you'll get the shortened URL; "

--- a/zipline/cli/commands/shorten.py
+++ b/zipline/cli/commands/shorten.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 from rich import print
@@ -31,6 +32,16 @@ async def shorten(
         envvar="ZIPLINE_TOKEN",
         prompt=True,
         hide_input=True,
+    ),
+    print_object: bool = Option(
+        bool(sys.stdout.isatty()),
+        "--object/--text",
+        "-o/-O",
+        help=(
+            "Choose how to format the output. If --text (or piped),\n"
+            "you'll get the shortened url; if --object (or on a TTY),\n"
+            "you'll get the raw Python object."
+        ),
     ),
     vanity: Optional[str] = Option(
         None,
@@ -78,4 +89,4 @@ async def shorten(
             except Exception as exception:
                 handle_api_errors(exception, server_url, traceback=verbose)
 
-    print(str(shortened_url))
+    print(shortened_url if print_object else str(shortened_url))

--- a/zipline/cli/commands/shorten.py
+++ b/zipline/cli/commands/shorten.py
@@ -38,8 +38,8 @@ async def shorten(
         "--object/--text",
         "-o/-O",
         help=(
-            "Choose how to format the output. If --text (or piped),\n"
-            "you'll get the shortened url; if --object (or on a TTY),\n"
+            "Choose how to format the output. If --text (or piped), "
+            "you'll get the shortened url; if --object (or on a TTY), "
             "you'll get the raw Python object."
         ),
     ),

--- a/zipline/cli/commands/shorten.py
+++ b/zipline/cli/commands/shorten.py
@@ -34,14 +34,16 @@ async def shorten(
         hide_input=True,
     ),
     print_object: bool = Option(
-        bool(sys.stdout.isatty()),
+        ...,
         "--object/--text",
         "-o/-O",
+        default_factory=lambda: bool(sys.stdout.isatty()),
         help=(
-            "Choose how to format the output. If --text (or piped), "
-            "you'll get the shortened url; if --object (or on a TTY), "
-            "you'll get the raw Python object."
+            "Choose how to format the output. "
+            "If --text (or piped), you'll get the shortened URL; "
+            "if --object (or on a TTY), you'll get the raw Python object."
         ),
+        envvar="ZIPLINE_PRINT_OBJECT",
     ),
     vanity: Optional[str] = Option(
         None,

--- a/zipline/cli/commands/shorten.py
+++ b/zipline/cli/commands/shorten.py
@@ -48,7 +48,7 @@ async def shorten(
     vanity: Optional[str] = Option(
         None,
         "--vanity",
-        "-v",
+        "-V",
         help="Specify a vanity name. A name will be generated automatically if this is not provided.",
     ),
     max_views: Optional[int] = Option(
@@ -91,4 +91,6 @@ async def shorten(
             except Exception as exception:
                 handle_api_errors(exception, server_url, traceback=verbose)
 
-    print(shortened_url if print_object else str(shortened_url))
+    if print_object:
+        print(shortened_url)
+    print(shortened_url.full_url)

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -58,14 +58,16 @@ async def upload(
         hide_input=True,
     ),
     print_object: bool = Option(
-        bool(sys.stdout.isatty()),
+        ...,
         "--object/--text",
         "-o/-O",
+        default_factory=lambda: bool(sys.stdout.isatty()),
         help=(
-            "Choose how to format the output. If --text (or piped), "
-            "you'll get a link to the uploaded file; if --object (or on a TTY), "
-            "you'll get the raw Python object."
+            "Choose how to format the output. "
+            "If --text (or piped), you'll get a link to the uploaded file; "
+            "if --object (or on a TTY), you'll get the raw Python object."
         ),
+        envvar="ZIPLINE_PRINT_OBJECT",
     ),
     format: Optional[NameFormat] = Option(
         None,

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -166,7 +166,7 @@ async def upload(
         async with Client(server_url, token) as client:
             try:
                 upload = await client.upload_file(
-                    payload,
+                    *payload,  # list[FileData]
                     compression_percent=compression_percent,
                     expiry=expiry.astimezone(tz=timezone.utc) if expiry else None,
                     format=format,

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -62,8 +62,8 @@ async def upload(
         "--object/--text",
         "-o/-O",
         help=(
-            "Choose how to format the output. If --text (or piped),\n"
-            "you'll get a link to the uploaded file; if --object (or on a TTY),\n"
+            "Choose how to format the output. If --text (or piped), "
+            "you'll get a link to the uploaded file; if --object (or on a TTY), "
             "you'll get the raw Python object."
         ),
     ),

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -113,11 +113,13 @@ async def upload(
     original_name: bool = Option(
         False,
         "--original-name/--generated-name",
-        "-o/-g",
+        "-G/-g",
         help="Specify whether the original name of the file should be preserved when downloading the file from Zipline.",
     ),
     folder: Optional[str] = Option(
         None,
+        "--folder",
+        "-F",
         help="Specify what folder the file should be added to after it is uploaded.",
     ),
     override_extension: Optional[str] = Option(

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -84,7 +84,11 @@ async def upload(
         None,
         "--expiry",
         "-E",
-        help="Specify when this file should expire. When this time expires, the file will be deleted from the Zipline instance.",
+        help=(
+            "Specify when this file should expire.\n"
+            "When this time expires, the file will be deleted from the Zipline instance.\n"
+            "This argument uses your system's local timezone, not UTC dates."
+        ),
     ),
     password: Optional[str] = Option(
         None,

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -61,7 +61,7 @@ async def upload(
         ...,
         "--object/--text",
         "-o/-O",
-        default_factory=lambda: bool(sys.stdout.isatty()),
+        default_factory=sys.stdout.isatty,
         help=(
             "Choose how to format the output. "
             "If --text (or piped), you'll get a link to the uploaded file; "

--- a/zipline/cli/commands/upload.py
+++ b/zipline/cli/commands/upload.py
@@ -10,7 +10,7 @@ from zipline.cli.commands._handling import handle_api_errors
 from zipline.cli.sync import sync
 from zipline.client import Client
 from zipline.enums import NameFormat
-from zipline.models import FileData, UploadResponse
+from zipline.models import FileData
 
 app = Typer()
 
@@ -157,7 +157,7 @@ async def upload(
         progress.update(task, description="Uploading file...", total=None)
         async with Client(server_url, token) as client:
             try:
-                uploaded_file: Union[UploadResponse, str] = await client.upload_file(
+                upload = await client.upload_file(
                     payload=file_data,
                     compression_percent=compression_percent,
                     expiry=expiry.astimezone(tz=timezone.utc) if expiry else None,
@@ -169,9 +169,8 @@ async def upload(
                     folder=folder,
                     override_extension=override_extension,
                     override_domain=override_domain,
-                    text_only=not print_object,  # pyright: ignore[reportCallIssue, reportArgumentType]
                 )
             except Exception as exception:
                 handle_api_errors(exception, server_url, traceback=verbose)
 
-        print(uploaded_file)
+        print(upload if print_object else " ".join(file.url for file in upload.files))

--- a/zipline/cli/sync.py
+++ b/zipline/cli/sync.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 from asyncio import run
 from functools import wraps
-from typing import Any, Callable, Coroutine, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    Params = ParamSpec("Params")
 
 Response = TypeVar("Response")
 
 
 def sync(
-    func: Callable[..., Coroutine[Any, Any, Response]],
-) -> Callable[..., Response]:
+    func: Callable[Params, Coroutine[Any, Any, Response]],
+) -> Callable[Params, Response]:
     """
     Decorator that takes an async function `func(...) -> Coroutine[Any, Any, Response]`
     and turns it into a synchronous function `() -> Response` by running
@@ -15,7 +22,7 @@ def sync(
     """
 
     @wraps(wrapped=func)
-    def wrapper(*args: Any, **kwargs: Any) -> Response:
+    def wrapper(*args: Params.args, **kwargs: Params.kwargs) -> Response:
         return run(func(*args, **kwargs))
 
     return wrapper

--- a/zipline/cli/sync.py
+++ b/zipline/cli/sync.py
@@ -2,15 +2,12 @@ from asyncio import run
 from functools import wraps
 from typing import Any, Callable, Coroutine, TypeVar
 
-from typing_extensions import ParamSpec
-
-Params = ParamSpec("Params")
 Response = TypeVar("Response")
 
 
 def sync(
-    func: Callable[Params, Coroutine[Any, Any, Response]],
-) -> Callable[Params, Response]:
+    func: Callable[..., Coroutine[Any, Any, Response]],
+) -> Callable[..., Response]:
     """
     Decorator that takes an async function `func(...) -> Coroutine[Any, Any, Response]`
     and turns it into a synchronous function `() -> Response` by running
@@ -18,7 +15,7 @@ def sync(
     """
 
     @wraps(wrapped=func)
-    def wrapper(*args: Params.args, **kwargs: Params.kwargs) -> Response:
+    def wrapper(*args: Any, **kwargs: Any) -> Response:
         return run(func(*args, **kwargs))
 
     return wrapper

--- a/zipline/cli/sync.py
+++ b/zipline/cli/sync.py
@@ -1,10 +1,24 @@
 from asyncio import run
 from functools import wraps
+from typing import Any, Callable, Coroutine, TypeVar
+
+from typing_extensions import ParamSpec
+
+Params = ParamSpec("Params")
+Response = TypeVar("Response")
 
 
-def sync(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
+def sync(
+    func: Callable[Params, Coroutine[Any, Any, Response]],
+) -> Callable[Params, Response]:  # pyright: ignore[reportExplicitAny]
+    """
+    Decorator that takes an async function `func(...) -> Coroutine[Any, Any, Response]`
+    and turns it into a synchronous function `() -> Response` by running
+    `asyncio.run(...)` under the hood.
+    """
+
+    @wraps(wrapped=func)
+    def wrapper(*args: Params.args, **kwargs: Params.kwargs) -> Response:
         return run(func(*args, **kwargs))
 
     return wrapper

--- a/zipline/cli/sync.py
+++ b/zipline/cli/sync.py
@@ -10,7 +10,7 @@ Response = TypeVar("Response")
 
 def sync(
     func: Callable[Params, Coroutine[Any, Any, Response]],
-) -> Callable[Params, Response]:  # pyright: ignore[reportExplicitAny]
+) -> Callable[Params, Response]:
     """
     Decorator that takes an async function `func(...) -> Coroutine[Any, Any, Response]`
     and turns it into a synchronous function `() -> Response` by running

--- a/zipline/client.py
+++ b/zipline/client.py
@@ -791,8 +791,7 @@ class Client:
     @overload
     async def upload_file(
         self,
-        payload: Union[FileData, List[FileData]],
-        *,
+        *payload: FileData,
         format: Optional[NameFormat] = ...,
         compression_percent: int = ...,
         expiry: Optional[Union[datetime.datetime, datetime.timedelta]] = ...,
@@ -809,8 +808,7 @@ class Client:
     @overload
     async def upload_file(
         self,
-        payload: Union[FileData, List[FileData]],
-        *,
+        *payload: FileData,
         format: Optional[NameFormat] = ...,
         compression_percent: int = ...,
         expiry: Optional[Union[datetime.datetime, datetime.timedelta]] = ...,
@@ -826,8 +824,7 @@ class Client:
 
     async def upload_file(
         self,
-        payload: Union[FileData, List[FileData]],
-        *,
+        *payload: FileData,
         format: Optional[NameFormat] = None,
         compression_percent: int = 0,
         expiry: Optional[Union[datetime.datetime, datetime.timedelta]] = None,
@@ -846,12 +843,12 @@ class Client:
 
         Parameters
         ----------
-        payload: Union[:class:`~zipline.models.FileData`, List[:class:`~zipline.models.FileData`]]
+        payload: *:class:`~zipline.models.FileData`
             Data regarding the file to upload.
 
             .. versionchanged:: 0.28.0
 
-                It is now possible to pass a list of :class:`~zipline.models.FileData` objects.
+                It is now possible to pass multiple :class:`~zipline.models.FileData` objects.
         format: Optional[:class:`~zipline.enums.NameFormat`]
             The format of the name to assign to the uploaded file, uses Zipline's configured name formatting by default.
 
@@ -950,11 +947,8 @@ class Client:
             headers["X-Zipline-No-Json"] = "true"
 
         formdata = aiohttp.FormData()
-        if isinstance(payload, list):
-            for file in payload:
-                formdata.add_field("file", file.data, filename=file.filename, content_type=file.mimetype)
-        else:
-            formdata.add_field("file", payload.data, filename=payload.filename, content_type=payload.mimetype)
+        for file in payload:
+            formdata.add_field("file", file.data, filename=file.filename, content_type=file.mimetype)
 
         r = Route("POST", "/api/upload")
         data = await self.http.request(r, headers=headers, data=formdata)

--- a/zipline/client.py
+++ b/zipline/client.py
@@ -175,7 +175,7 @@ class Client:
     async def get_user(self, id: str, /) -> User:
         """|coro|
 
-        Retreive a user with given id.
+        Retrieve a user with given id.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR does the following things:

- [x] Properly typehints the `sync()` decorator, so it explicitly expects a coroutine.
  - Fixes the hypothetical problem of someone making an async CLI command, using `sync()`, and then realizing they don't need the CLI command's function to be async. If they then forget to remove `sync()`, the command will break. Now, the user's typechecker of choice will complain loudly (an error for basedpyright) if `sync()` is used on a non-async function.
- [x] Fixes the `--expiry` option on the `ziplinepy upload` command defaulting to UTC instead of the system timezone. Not sure if this is technically a "bug", but it surprised me when I ran into it at least. At the very least it isn't expected behavior.
  - Ideally, we would let the user specify what timezone the datetime should use during parsing, but Click doesn't appear to support that right now. If it does at some point in the future, no changes should be required on our side to use it other than a Click version bump.
- [x] Adds a `--text` / `--object` option to `upload` and `shorten`.
  - This will return the full Python object (`UploadResponse` for `upload`; `URL` for `shorten`) when a TTY is detected or when the `--object` argument is passed. The behavior of copying to clipboard via a pipe still works, because the default for this argument is determined by a call to `bool(sys.stdout.isatty())`. This means that for pipes or other use cases where a TTY is not allocated, only the url to the uploaded file or shortened link will be printed.
  - For `shorten` specifically, this has the downside of printing whatever was passed to `--password` (if anything) to stdout if `--text` is not explicitly passed. If this is unwanted, I can make this change only apply to `upload`, although I do think it serves more of a purpose on `shorten` than `upload`.
- [x] **(Library change)** Allows uploading multiple files at once, both through `client.upload_file()` and the `ziplinepy upload` command. Documentation has been update to reflect this change as well, as you can now pass a `List[FileData]` to `client.upload_file()`.
  - Note that I'm not sure what Zipline's limit to how many files can be uploaded at once is, so that should be investigated before merging this.

![image](https://github.com/user-attachments/assets/eeec57f2-6f1b-47f4-8cfc-86ba6bb8c6d3)
